### PR TITLE
Add trakt module that allows searching

### DIFF
--- a/tvshowcountdown/tvshow/templates/index.html
+++ b/tvshowcountdown/tvshow/templates/index.html
@@ -1,6 +1,12 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1>Testing</h1>
+<form class="text-center" action="/results" method="get">
+    <div class="row">
+        <div class="form-inline col-md-6 col-md-offset-3">
+            <input name="term" type="text" class="form-control" placeholder="Search" value="{{ term }}" autofocus>
+            <button type="submit" class="btn btn-default">Search</button>
+        </div>
+    </div>
+</form>
 {% endblock %}
-

--- a/tvshowcountdown/tvshow/trakt.py
+++ b/tvshowcountdown/tvshow/trakt.py
@@ -1,0 +1,30 @@
+import requests
+from django.conf import settings
+
+
+headers = {
+    'trakt-api-version': '2',
+    'trakt-api-key': settings.TRAKT_API_KEY
+}
+
+
+def search(search_term, type='show', year=None):
+    '''
+    :param str search_term: (required) the term to search trakt with
+    :param str type: which type of program to search for. defaults to 'show'
+    :param int year: limit search to this year
+    :returns: list of results
+    '''
+
+    url = 'https://api-v2launch.trakt.tv/search?query={}&type={}'.format(search_term, type)
+    if year:
+        year = int(year)
+        url += '&year={}'.format(year)
+    r = requests.get(url, headers=headers)
+    result = []
+    for i in r.json():
+        result.append({
+            'name': i['show']['title'],
+            'year': i['show']['year'],
+            'slug': i['show']['ids']['slug']})
+    return result

--- a/tvshowcountdown/tvshowcountdown/settings.py
+++ b/tvshowcountdown/tvshowcountdown/settings.py
@@ -105,3 +105,5 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
+
+TRAKT_API_KEY = os.environ.get('TRAKT_API_KEY', False)


### PR DESCRIPTION
Fixes https://github.com/rmotr/003-demo-day-tv-show-countdown/issues/5

Django will get the API key from the environment variable `TRAKT_API_KEY`. Here is an example of it from the command line:
```
$ TRAKT_API_KEY=<MY API KEY> ./manage.py shell
Python 3.4.2 (default, Jun 19 2015, 11:32:29) 
[GCC 4.9.1] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import tvshow.trakt
>>> tvshow.trakt.search('mr robot')
[{'slug': 'mr-robot', 'year': 2015, 'name': 'Mr. Robot'}, {'slug': 'catchphrase', 'year': 1986, 'name': 'Catchphrase'}, {'slug': 'telebugs', 'year': None, 'name': 'Telebugs'}, {'slug': 'hero-factory', 'year': 2010, 'name': 'Hero Factory'}, {'slug': 'mobile-suit-gundam-the-origin-644e759b-73a1-4bf6-9f3e-1330270a2426', 'year': 2015, 'name': 'MOBILE SUIT GUNDAM THE ORIGIN'}, {'slug': 'whiz-kids', 'year': 1983, 'name': 'Whiz Kids'}]
```
